### PR TITLE
Support -d for switches with a numeric value

### DIFF
--- a/lib/gs-ruby/command.rb
+++ b/lib/gs-ruby/command.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'open3'
 
 module GS
@@ -65,9 +66,18 @@ module GS
     private
 
     def build_switches
-      options
-        .map { |(n, v)| v ? "-s#{n}=#{v}" : "-d#{n}" }
-        .join(' ')
+      options.map do |(n, v)|
+        flag   = '-d'
+        option = n
+
+        if v
+          flag = '-s' if v.is_a?(String)
+
+          option = "#{n}=#{v}"
+        end
+
+        "#{flag}#{option}"
+      end.join(' ')
     end
   end
 end

--- a/spec/gs-ruby/command_spec.rb
+++ b/spec/gs-ruby/command_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 describe GS::Command do
@@ -67,6 +68,42 @@ describe GS::Command do
 
     it 'returns the resulting process status' do
       expect(command.run(inputs)).to be(status)
+    end
+  end
+
+  describe '#build_switches' do
+    let(:build_switches_call) do
+      command.send(:build_switches)
+    end
+
+    context 'when the value is not present' do
+      before do
+        command.option(GS::NO_PAUSE)
+      end
+
+      it 'uses -d without a value' do
+        expect(build_switches_call).to eq('-dBATCH -dNOPAUSE')
+      end
+    end
+
+    context 'when the value is a string' do
+      before do
+        command.option(GS::PROCESS_COLOR_MODEL, 'DeviceCMYK')
+      end
+
+      it 'uses -s with a value' do
+        expect(build_switches_call).to eq('-dBATCH -sProcessColorModel=DeviceCMYK')
+      end
+    end
+
+    context 'when the value is not a string' do
+      before do
+        command.option(GS::PDFA_COMPATIBILITY_POLICY, 1)
+      end
+
+      it 'uses -d with a value' do
+        expect(build_switches_call).to eq('-dBATCH -dPDFACompatibilityPolicy=1')
+      end
     end
   end
 end


### PR DESCRIPTION
This change allows to use `-d` flags/switches for variables with a value
when passing a non string value.

Ghostscript supports -dVAR=VALUE for non string values.
See: https://ghostscript.com/doc/9.52/Use.htm#Parameters

The existing version of gs-ruby (0.1) automatically uses `-s` if a value
is passed. This adds support to pass a non-string value, e.g. numeric
ones, where -d should be used.

Older versions (tested with Ghostscript 9.06) allows `-s` for variables
such as `PDFACompatibilityPolicy` with a value like `1`.
More recent versions (tested with Ghostscript 9.26) have issues there.

Example:
```bash
rm -f example.pdf && curl https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf -o example.pdf
gs -dPDFA=1 -dBATCH -dNOPAUSE -dPDFACompatibilityPolicy=1 -dUseCIEColor -sProcessColorModel=DeviceRGB -sDEVICE=pdfwrite -sOutputFile=converted_example.pdf example.pdf
cat converted_example.pdf | tr -d '\000' | grep pdfaid
```
Where using `-s` for `PDFA` and `PDFACompatibilityPolicy` caused the
conversion from PDF to PDF/A to fail

A usage example here would be:
```ruby
GS.run(input_path) do |command|
  command.option(GS::PDFA, 1)
  command.option(GS::BATCH)
  command.option(GS::NO_PAUSE)
  command.option('UseCIEColor')
  command.option('ProcessColorModel', 'DeviceRGB')
  command.option('DEVICE', 'pdfwrite')
  command.option(GS::PDFA_COMPATIBILITY_POLICY, 1)
  command.option(GS::OUTPUT_FILE, output_path)

  command.logger = logger
end
```